### PR TITLE
aws-codedeploy-agent, CloudWatchMonitoringScriptsのインストール処理を追加

### DIFF
--- a/roles/aws-codedeploy-agent/tasks/main.yml
+++ b/roles/aws-codedeploy-agent/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Install ruby
+  shell: amazon-linux-extras install ruby2.4 -y
+
+- name: Download aws-codedeploy-agent Installer
+  become: no
+  shell: aws s3 cp s3://aws-codedeploy-ap-northeast-1/latest/install . --region ap-northeast-1
+  args:
+    chdir: /home/{{ app_user }}
+
+- name: chmod aws-codedeploy-agent Installer
+  file:
+    path: /home/{{ app_user }}/install
+    mode: 0755
+
+- name: Install aws-codedeploy-agent
+  shell: /home/{{ app_user }}/install auto
+
+- name: aws-codedeploy-agent start
+  service: enabled=yes name=codedeploy-agent state=started

--- a/roles/aws-scripts-mon/tasks/dependence-packages.yml
+++ b/roles/aws-scripts-mon/tasks/dependence-packages.yml
@@ -1,0 +1,9 @@
+- name: install dependence-packages
+  yum:
+    state: present
+    name:
+      - perl-Switch
+      - perl-DateTime
+      - perl-Sys-Syslog
+      - perl-LWP-Protocol-https
+      - perl-Digest-SHA.x86_64

--- a/roles/aws-scripts-mon/tasks/download-script.yml
+++ b/roles/aws-scripts-mon/tasks/download-script.yml
@@ -1,0 +1,7 @@
+- name: Download CloudWatchMonitoringScripts
+  get_url:
+    url: http://aws-cloudwatch.s3.amazonaws.com/downloads/CloudWatchMonitoringScripts-1.2.2.zip
+    dest: /opt
+
+- name: unzip CloudWatchMonitoringScripts.zip
+  unarchive: src=/opt/CloudWatchMonitoringScripts-1.2.2.zip remote_src=yes dest=/opt/

--- a/roles/aws-scripts-mon/tasks/main.yml
+++ b/roles/aws-scripts-mon/tasks/main.yml
@@ -1,0 +1,3 @@
+- import_tasks: dependence-packages.yml
+- import_tasks: download-script.yml
+- import_tasks: set-cron-tab.yml

--- a/roles/aws-scripts-mon/tasks/set-cron-tab.yml
+++ b/roles/aws-scripts-mon/tasks/set-cron-tab.yml
@@ -1,0 +1,6 @@
+- name: Set cron-tab
+  cron:
+    name: "mon-put-instance-data.pl"
+    minute: "*/5"
+    user: "{{ app_user }}"
+    job: "/opt/aws-scripts-mon/mon-put-instance-data.pl --mem-used-incl-cache-buff --mem-util --mem-used --mem-avail --disk-space-util --disk-path=/ --from-cron"

--- a/site.yml
+++ b/site.yml
@@ -8,4 +8,5 @@
     - nginx
     - composer
     - aws-codedeploy-agent
+    - aws-scripts-mon
     - qiita-stocker-backend

--- a/site.yml
+++ b/site.yml
@@ -7,4 +7,5 @@
     - php-fpm
     - nginx
     - composer
+    - aws-codedeploy-agent
     - qiita-stocker-backend


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-ansible/issues/4

# Doneの定義
- EC2インスタンスがCodeDeployと通信出来るようになっている事
- CloudWatchからメモリ、ディスク容量の確認が出来るようになっている事

# 変更点概要

## 仕様的変更点概要
- CodeDeployとインスタンスが通信出来るように `codedeploy-agent` を導入
- ディスク、メモリ使用量をCloudWatchログに送信出来るスクリプトを設置

## 技術的変更点概要
- `aws-codedeploy-agent` をインストール
- `CloudWatchMonitoringScripts` をインストールして定期的にCloudWatchにサーバーのメモリ、ディスク容量等を送信するように改修
- `sudo service codedeploy-agent status` をサーバー内で実施して `codedeploy-agent` が正常動作している事を確認

# 補足情報
動作させるには https://github.com/nekochans/qiita-stocker-terraform/pull/31 が適応されている必要がある。（ステージング環境で既に動作確認済）